### PR TITLE
Fixing toInteger' in BitWord

### DIFF
--- a/rewire-user/src/ReWire/BitWord.hs
+++ b/rewire-user/src/ReWire/BitWord.hs
@@ -168,12 +168,20 @@ toIntLE' (b:bs) = toInt b Prelude.+ 2 Prelude.* toIntLE' bs
 toInt' :: [Bool] -> Int
 toInt' = toIntLE' . reverse
 
+-- fromBool :: Bool -> Integer
+-- fromBool = toInteger . fromEnum
+
+-- | Why not just this?
 fromBool :: Bool -> Integer
-fromBool = toInteger . fromEnum
+fromBool True  = 1
+fromBool False = 0
 
 -- should check that this works on big-endian
+-- toInteger' :: Vec n Bool -> Integer
+-- toInteger' = foldr (\ x s -> fromBool x Prelude.+ 2 Prelude.* s) 0
+
 toInteger' :: Vec n Bool -> Integer
-toInteger' = foldr (\ x s -> fromBool x Prelude.+ 2 Prelude.* s) 0
+toInteger' = foldl (\ acc b -> 2 Prelude.* acc Prelude.+ fromBool b) 0
 
 -- w is bigendian
 resize' :: Int -> [Bool] -> [Bool]


### PR DESCRIPTION
The function toInteger' in BitWord was incorrect, and this caused some heartburn in developing some simple examples. I left the old version commented out. The basic problem is that toInteger' should be computed with a left fold rather than a right fold.